### PR TITLE
9 make cpu methods argument order consistent

### DIFF
--- a/arch/arm/op_helper.c
+++ b/arch/arm/op_helper.c
@@ -91,7 +91,7 @@ void tlb_fill(CPUState *env1, target_ulong addr, int is_write, int mmu_idx,
             if (tb) {
                 /* the PC is inside the translated code. It means that we have
                    a virtual CPU fault */
-                cpu_restore_state(tb, env, pc);
+                cpu_restore_state(env, tb, pc);
             }
         }
         raise_exception(env->exception_index);

--- a/arch/i386/op_helper.c
+++ b/arch/i386/op_helper.c
@@ -4717,7 +4717,7 @@ void tlb_fill(CPUState *env1, target_ulong addr, int is_write, int mmu_idx,
             if (tb) {
                 /* the PC is inside the translated code. It means that we have
                    a virtual CPU fault */
-                cpu_restore_state(tb, env, pc);
+                cpu_restore_state(env, tb, pc);
             }
         }
         raise_exception_err(env->exception_index, env->error_code);

--- a/arch/ppc/op_helper.c
+++ b/arch/ppc/op_helper.c
@@ -3681,7 +3681,7 @@ void tlb_fill(CPUState *env1, target_ulong addr, int is_write, int mmu_idx,
             if (likely(tb)) {
                 /* the PC is inside the translated code. It means that we have
                    a virtual CPU fault */
-                cpu_restore_state(tb, env, pc);
+                cpu_restore_state(env, tb, pc);
             }
         }
         helper_raise_exception_err(env->exception_index, env->error_code);

--- a/arch/sparc/op_helper.c
+++ b/arch/sparc/op_helper.c
@@ -3782,7 +3782,7 @@ static void cpu_restore_state2(void *retaddr)
         if (tb) {
             /* the PC is inside the translated code. It means that we have
                a virtual CPU fault */
-            cpu_restore_state(tb, env, pc);
+            cpu_restore_state(env, tb, pc);
         }
     }
 }

--- a/arch/translate-all.c
+++ b/arch/translate-all.c
@@ -41,13 +41,10 @@ void cpu_gen_init(void)
     tcg_context_init(&GLOBAL_tcg_ctx);
 }
 
-/* return non zero if the very first instruction is invalid so that
-   the virtual CPU can trigger an exception.
-
-   '*gen_code_size_ptr' contains the size of the generated code (host
+/* '*gen_code_size_ptr' contains the size of the generated code (host
    code).
 */
-int cpu_gen_code(CPUState *env, TranslationBlock *tb, int *gen_code_size_ptr)
+void cpu_gen_code(CPUState *env, TranslationBlock *tb, int *gen_code_size_ptr)
 {
     TCGContext *s = &GLOBAL_tcg_ctx;
     uint8_t *gen_code_buf;
@@ -67,8 +64,6 @@ int cpu_gen_code(CPUState *env, TranslationBlock *tb, int *gen_code_size_ptr)
 
     gen_code_size = tcg_gen_code(s, gen_code_buf);
     *gen_code_size_ptr = gen_code_size;
-
-    return 0;
 }
 
 /* The cpu state corresponding to 'searched_pc' is restored.

--- a/arch/translate-all.c
+++ b/arch/translate-all.c
@@ -73,8 +73,8 @@ int cpu_gen_code(CPUState *env, TranslationBlock *tb, int *gen_code_size_ptr)
 
 /* The cpu state corresponding to 'searched_pc' is restored.
  */
-int cpu_restore_state(TranslationBlock *tb,
-                      CPUState *env, unsigned long searched_pc)
+int cpu_restore_state(CPUState *env,
+		TranslationBlock *tb, unsigned long searched_pc)
 {
     TCGContext *s = &GLOBAL_tcg_ctx;
     int j;

--- a/exec.c
+++ b/exec.c
@@ -740,7 +740,7 @@ void tb_invalidate_phys_page_range_inner(tb_page_addr_t start, tb_page_addr_t en
                 restore the CPU state */
 
                 current_tb_modified = 1;
-                cpu_restore_state(current_tb, env, env->mem_io_pc);
+                cpu_restore_state(env, current_tb, env->mem_io_pc);
                 cpu_get_tb_cpu_state(env, &current_pc, &current_cs_base,
                                      &current_flags);
             }

--- a/exports.c
+++ b/exports.c
@@ -246,7 +246,7 @@ void tlib_restore_context()
 
   pc = (unsigned long)global_retaddr;
   tb = tb_find_pc(pc);
-  cpu_restore_state(tb, cpu, pc);
+  cpu_restore_state(cpu, tb, pc);
 }
 
 void* tlib_export_state()

--- a/include/exec-all.h
+++ b/include/exec-all.h
@@ -72,7 +72,7 @@ void restore_state_to_opc(CPUState *env, struct TranslationBlock *tb,
                           int pc_pos);
 
 void cpu_gen_init(void);
-int cpu_gen_code(CPUState *env, struct TranslationBlock *tb,
+void cpu_gen_code(CPUState *env, struct TranslationBlock *tb,
                  int *gen_code_size_ptr);
 int cpu_restore_state(CPUState *env, struct TranslationBlock *tb,
 		unsigned long searched_pc);

--- a/include/exec-all.h
+++ b/include/exec-all.h
@@ -74,8 +74,8 @@ void restore_state_to_opc(CPUState *env, struct TranslationBlock *tb,
 void cpu_gen_init(void);
 int cpu_gen_code(CPUState *env, struct TranslationBlock *tb,
                  int *gen_code_size_ptr);
-int cpu_restore_state(struct TranslationBlock *tb,
-                      CPUState *env, unsigned long searched_pc);
+int cpu_restore_state(CPUState *env, struct TranslationBlock *tb,
+		unsigned long searched_pc);
 void cpu_resume_from_signal(CPUState *env1, void *puc);
 TranslationBlock *tb_gen_code(CPUState *env, 
                               target_ulong pc, target_ulong cs_base, int flags,


### PR DESCRIPTION
Changed the argument order of `cpu_restore_state` to match with `cpu_gen_code` and removed `cpu_gen_code`'s return value.
