### PR TITLE
Force SPARC target physical address bits to be always 36.

### DIFF
--- a/arch/sparc/cpu.h
+++ b/arch/sparc/cpu.h
@@ -7,6 +7,11 @@
 #define TARGET_SPARC64 1
 #endif
 
+#ifdef TARGET_PHYS_ADDR_BITS
+#undef TARGET_PHYS_ADDR_BITS
+#define TARGET_PHYS_ADDR_BITS 36
+#endif
+
 #if !defined(TARGET_SPARC64)
 #define TARGET_LONG_BITS 32
 #define TARGET_FPREGS 32

--- a/include/targphys.h
+++ b/include/targphys.h
@@ -5,16 +5,22 @@
 
 #ifdef TARGET_PHYS_ADDR_BITS
 /* target_phys_addr_t is the type of a physical address (its size can
-   be different from 'target_ulong').  */
+   be different from 'target_ulong').
 
-#if TARGET_PHYS_ADDR_BITS == 32
-typedef uint32_t target_phys_addr_t;
-#define TARGET_PHYS_ADDR_MAX UINT32_MAX
-#define TARGET_FMT_plx "%08x"
-#elif TARGET_PHYS_ADDR_BITS == 64
-typedef uint64_t target_phys_addr_t;
-#define TARGET_PHYS_ADDR_MAX UINT64_MAX
-#define TARGET_FMT_plx "%016" PRIx64
+   SPARC architecture has 36-bits wide physical address, that's why
+   we use `<=` operators below instead of simple `==`
+   */
+
+#if TARGET_PHYS_ADDR_BITS <= 32
+  typedef uint32_t target_phys_addr_t;
+  #define TARGET_PHYS_ADDR_MAX UINT32_MAX
+  #define TARGET_FMT_plx "%08x"
+#elif TARGET_PHYS_ADDR_BITS <= 64
+  typedef uint64_t target_phys_addr_t;
+  #define TARGET_PHYS_ADDR_MAX UINT64_MAX
+  #define TARGET_FMT_plx "%016" PRIx64
+#else
+  #error "Target physical address width is too big"
 #endif
 #endif
 


### PR DESCRIPTION
This commit adds support for non-standard (i.e., 32 or 64) widths
of physical addresses. It is related to issue #16.
