### PR TITLE
[#29] Improve weak implementation of tlib_abort.

### DIFF
--- a/callbacks.c
+++ b/callbacks.c
@@ -22,7 +22,12 @@
 
 DEFAULT_VOID_HANDLER1(void tlib_on_translation_block_find_slow, uint32_t pc)
 
-DEFAULT_VOID_HANDLER1(void tlib_abort, char *message)
+void tlib_abort(char *message) __attribute__((weak));
+
+void tlib_abort(char *message)
+{
+  abort();
+}
 
 DEFAULT_VOID_HANDLER2(void tlib_log, enum log_level level, char* message)
 


### PR DESCRIPTION
Instead of doing nothing it now executes abort().
